### PR TITLE
gpt-5-nano and default transcribe model

### DIFF
--- a/app/src/main/java/com/example/aiaudiotranscription/api/OpenAIApiService.kt
+++ b/app/src/main/java/com/example/aiaudiotranscription/api/OpenAIApiService.kt
@@ -6,7 +6,7 @@ import retrofit2.http.*
 
 // Add constants
 const val MODEL_WHISPER = "whisper-1"
-const val MODEL_GPT = "gpt-4o-mini"
+const val MODEL_GPT_TEXT = "gpt-5-nano"
 const val MODEL_GPT_4O_TRANSCRIBE = "gpt-4o-transcribe"
 
 const val MODEL_GPT_4O_MINI_TRANSCRIBE = "gpt-4o-mini-transcribe-2025-12-15"
@@ -55,7 +55,6 @@ data class Message(
 )
 
 data class ChatRequest(
-    val model: String = MODEL_GPT,
+    val model: String = MODEL_GPT_TEXT,
     val messages: List<Message>,
-    val temperature: Double = 0.3,
 )

--- a/app/src/main/java/com/example/aiaudiotranscription/presentation/SettingsActivity.kt
+++ b/app/src/main/java/com/example/aiaudiotranscription/presentation/SettingsActivity.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.aiaudiotranscription.api.MODEL_GPT
+import com.example.aiaudiotranscription.api.MODEL_GPT_TEXT
 import com.example.aiaudiotranscription.api.MODEL_WHISPER
 import com.example.aiaudiotranscription.api.MODEL_GPT_4O_TRANSCRIBE
 import com.example.aiaudiotranscription.api.MODEL_GPT_4O_MINI_TRANSCRIBE
@@ -82,7 +82,7 @@ fun SettingsScreen(
     LaunchedEffect(Unit) {
         storedApiKey = SharedPrefsUtils.getApiKey(context) ?: ""
         cleanupPrompt = SharedPrefsUtils.getCleanupPrompt(context)
-        selectedModel = SharedPrefsUtils.getTranscriptionModel(context, MODEL_WHISPER)
+        selectedModel = SharedPrefsUtils.getTranscriptionModel(context, MODEL_GPT_4O_MINI_TRANSCRIBE)
         language = SharedPrefsUtils.getLanguage(context)
         whisperPrompt = SharedPrefsUtils.getWhisperPrompt(context)
         gptPrompt = SharedPrefsUtils.getGptPrompt(context)
@@ -484,8 +484,8 @@ private fun testApiKey(context: Context, apiKey: String, onResult: (List<ModelSt
                             modelIds.contains(MODEL_WHISPER)
                         ),
                         ModelStatus(
-                            "GPT Model (${MODEL_GPT})", 
-                            modelIds.contains(MODEL_GPT)
+                            "GPT Model (${MODEL_GPT_TEXT})",
+                            modelIds.contains(MODEL_GPT_TEXT)
                         ),
                         ModelStatus(
                             "GPT-4o Transcribe Model (${MODEL_GPT_4O_TRANSCRIBE})", 


### PR DESCRIPTION
This pull request updates the default GPT model used throughout the app to `gpt-5-nano` (referenced as `MODEL_GPT_TEXT`) instead of the previous `gpt-4o-mini`. It also changes the default transcription model in the settings screen and ensures all relevant references and UI labels are updated accordingly.

**Model configuration updates:**

* Changed the default GPT model constant from `MODEL_GPT` (`gpt-4o-mini`) to `MODEL_GPT_TEXT` (`gpt-5-nano`) in `OpenAIApiService.kt`, and updated all usages and imports to reflect this change. [[1]](diffhunk://#diff-35dbb53a90b577ca428ff2521479abcc7186400739e3ef3779722c9253a63481L9-R9) [[2]](diffhunk://#diff-a971457c5d7234dceba69378f4b8b08cad89bac15dec787553e0ce1d01485d5eL23-R23) [[3]](diffhunk://#diff-a971457c5d7234dceba69378f4b8b08cad89bac15dec787553e0ce1d01485d5eL487-R488)
* Updated the default model used in the `ChatRequest` data class to `MODEL_GPT_TEXT`.

**Settings UI and behavior:**

* Changed the default selected transcription model in the settings screen to `MODEL_GPT_4O_MINI_TRANSCRIBE` instead of `MODEL_WHISPER`.
* Updated the model status display in the settings test API key function to use `MODEL_GPT_TEXT` instead of `MODEL_GPT`.